### PR TITLE
Fix dependency tree for webpack

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -24,9 +24,7 @@
   },
   "dependencies": {
     "color": "^0.11.1",
-    "hex-rgb": "^1.0.0",
     "history": "2.0.0-rc2",
-    "marked": "^0.3.5",
     "react": "^0.14.7",
     "react-dom": "^0.14.8",
     "react-router": "2.0.0-rc5"

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
     "example": "babel-node ./examples/server"
   },
   "dependencies": {
+    "marked": "^0.3.5"
+  },
+  "peerDependencies": {
     "color": "^0.11.1",
-    "hex-rgb": "^1.0.0",
     "history": "2.0.0-rc2",
-    "marked": "^0.3.5",
+    "radium": "^0.16.2",
     "react": "^0.14.7",
     "react-router": "2.0.0-rc5"
   },
@@ -50,10 +52,8 @@
     "jscs": "^2.10.1",
     "json-loader": "^0.5.3",
     "lodash": "^4.0.0",
-    "moment": "^2.12.0",
-    "npm": "^3.5.3",
+    "mocha": "^2.4.5",
     "postcss-loader": "^0.6.0",
-    "radium": "^0.16.2",
     "react-addons-test-utils": "^0.14.3",
     "react-transform-hmr": "^1.0.0",
     "rimraf": "^2.4.3",

--- a/src/styles/font.js
+++ b/src/styles/font.js
@@ -14,12 +14,12 @@ export default {
     loose: 1.4,
   },
   size: {
-    smallest: (10 / base) + 'rem',
-    smaller: (11 / base) + 'rem',
-    small: (12 / base) + 'rem',
+    smallest: `${10 / base}rem`,
+    smaller: `${11 / base}rem`,
+    small: `${12 / base}rem`,
     base: '1rem',
-    large: (16 / base) + 'rem',
-    larger: (18 / base) + 'rem',
+    large: `${16 / base}rem`,
+    larger: `${18 / base}rem`,
     largest: '1.5rem',
   },
   weight: {

--- a/src/styles/padding.js
+++ b/src/styles/padding.js
@@ -4,4 +4,4 @@ export default {
   quarter: '0.375rem',
   two: '3rem',
   five: '7.5rem',
-}
+};


### PR DESCRIPTION
- Make color, history, radium, react, and react-router peer dependencies
- Remove unused hex-rgb dependency
- Add missing mocha dependency
- Use string interpolation instead of concatenation in styles/font