### PR TITLE
allow events to be overwritten by exampleProps

### DIFF
--- a/src/components/Sandbox.jsx
+++ b/src/components/Sandbox.jsx
@@ -64,7 +64,11 @@ export default class Sandbox extends React.Component {
       };
     });
 
-    const props = Object.assign(currentComponent.props || {}, currentComponent.component.exampleProps || {}, events);
+    const props = Object.assign(
+      currentComponent.props || {},
+      events,
+      currentComponent.component.exampleProps || {}
+    );
 
     const console = (
       <Console style={{ paddingTop: Styles.padding.default }} messages={this.state.messages} />


### PR DESCRIPTION
Should make working with GanttChart in finechina a bit easier.