### PR TITLE
Turn off StyleRoot warnings

### DIFF
--- a/src/components/TestStatus.jsx
+++ b/src/components/TestStatus.jsx
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import 'mocha/mocha.js';
+import radium from 'radium';
 import React from 'react';
 import Test from './Test';
 
@@ -19,6 +20,9 @@ export default class TestStatus extends React.Component {
     this.state = {
       tests: {},
     };
+
+    // Prevent getting errors about needing StyleRoot wrapper
+    radium.TestMode.enable();
 
     mocha.setup('bdd');
   }


### PR DESCRIPTION
Prior to this, when you opened certain components, you'd see warnings in the console about needing `StyleRoot`. This was because the browser test runner did not have these warnings turned off. Now it does.