### PR TITLE
Support multiple example prop states

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,12 +13,18 @@
     "describe": false
   },
   "rules": {
+    "consistent-return": 1,
+    "arrow-body-style": 0,
     "max-len": 0,
     "no-use-before-define": [2, "nofunc"],
     "no-unused-expressions": 0,
     "no-console": 0,
     "space-before-function-paren": 0,
     "react/prefer-stateless-function": 0,
-    "react/no-multi-comp": 0
+    "react/no-multi-comp": 0,
+    "react/no-did-update-set-state": 0,
+    "no-param-reassign": 0,
+    "new-cap": 0,
+    "newline-per-chained-call": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "radium": "0.18.0",
     "react": "15.2.1",
     "react-dom": "15.2.1",
-    "react-router": "2.4.0"
+    "react-router": "2.4.0",
+    "react-tabs": "0.8.2"
   },
   "devDependencies": {
     "autoprefixer": "^6.0.3",

--- a/src/components/PropsEditor.jsx
+++ b/src/components/PropsEditor.jsx
@@ -1,13 +1,14 @@
 import _ from 'lodash';
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import Styles from '../styles';
 import PropInput from './PropInput';
 
-export default class PropsEditor extends React.Component {
+export default class PropsEditor extends Component {
   static propTypes = {
-    component: React.PropTypes.func,
-    onUpdateProps: React.PropTypes.func,
-    style: React.PropTypes.object,
+    component: PropTypes.func,
+    onUpdateProps: PropTypes.func,
+    style: PropTypes.object,
   };
 
   static labelStyles = {
@@ -16,36 +17,174 @@ export default class PropsEditor extends React.Component {
     color: Styles.color.grey37,
   };
 
-  static examplePropsLabelStyles = {
-    ...PropsEditor.labelStyles,
-    marginTop: Styles.padding.default,
+  static preStyles = {
+    paddingTop: '1rem',
+    paddingRight: '1rem',
+    paddingBottom: '1rem',
+    paddingLeft: '1rem',
+    backgroundColor: Styles.color.white,
+    height: 300,
+    overflow: 'auto',
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      customProps: {},
+    };
+
+    // We immediately call onUpdateProps if there is an example state selected
+    // by default
+    const { component = {}, onUpdateProps } = props;
+    const { exampleProps } = component;
+    if (exampleProps) {
+      if (Array.isArray(exampleProps)) {
+        onUpdateProps(exampleProps[0].props);
+      } else {
+        onUpdateProps(exampleProps);
+      }
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { component = {} } = this.props;
+    const { component: oldComponent = {} } = prevProps;
+
+    if (oldComponent.name !== component.name || oldComponent.displayName !== component.displayName) {
+      this.handleSelect(this.lastSelectedTabIndex || 0);
+    }
+  }
+
+  handleUpdateProps = (event, propName, value) => {
+    const { onUpdateProps } = this.props;
+
+    const customProps = {
+      ...this.state.customProps,
+      [propName]: value,
+    };
+
+    this.setState({
+      customProps,
+    });
+
+    onUpdateProps(customProps);
+  };
+
+  handleSelect = (selectedIndex) => {
+    const { component = {}, onUpdateProps } = this.props;
+    const { exampleProps } = component;
+
+    // Clear custom props because form will always be cleared when we change tabs
+    this.setState({ customProps: {} });
+
+    let totalTabCount = 1; // always custom
+    if (exampleProps) {
+      if (Array.isArray(exampleProps)) {
+        // New style, with multiple states
+        totalTabCount += exampleProps.length;
+      } else {
+        // Old style, just one example state
+        totalTabCount += 1;
+      }
+    }
+
+    let newProps;
+    if (selectedIndex === totalTabCount - 1) {
+      // Switched to custom tab, which starts out blank
+      newProps = {};
+    } else if (Array.isArray(exampleProps)) {
+      newProps = exampleProps[selectedIndex].props;
+    } else {
+      newProps = exampleProps;
+    }
+
+    onUpdateProps(newProps);
+
+    this.lastSelectedTabIndex = selectedIndex;
   };
 
   renderPropInputs() {
-    return _.map(this.props.component.propTypes, (propType, propName) => (
+    const { component = {} } = this.props;
+
+    return _.map(component.propTypes, (propType, propName) => (
       <tr key={propName}>
         <td>
           {propName}
         </td>
         <td style={{ width: '20px' }}></td>
         <td>
-          <PropInput name={propName} type={propType} onChange={this.props.onUpdateProps} />
+          <PropInput name={propName} type={propType} onChange={this.handleUpdateProps} />
         </td>
       </tr>
     ));
+  }
+
+  renderTabs() {
+    const { component = {} } = this.props;
+    const tabs = [];
+
+    if (component.exampleProps) {
+      if (Array.isArray(component.exampleProps)) {
+        // New style, with multiple states
+        component.exampleProps.forEach(({ name }) => {
+          tabs.push(`${name} State`);
+        });
+      } else {
+        // Old style, just one example state
+        tabs.push('Example State');
+      }
+    }
+
+    tabs.push('Custom Props');
+
+    return tabs.map(name => <Tab key={name}>{name}</Tab>);
+  }
+
+  renderTabPanels() {
+    const { component = {} } = this.props;
+    const panels = [];
+
+    if (component.exampleProps) {
+      if (Array.isArray(component.exampleProps)) {
+        // New style, with multiple states
+        component.exampleProps.forEach(({ props }) => {
+          panels.push(props);
+        });
+      } else {
+        // Old style, just one example state
+        panels.push(component.exampleProps);
+      }
+    }
+
+    return panels.map((json, index) => {
+      return (
+        <TabPanel key={String(index)}>
+          <pre style={PropsEditor.preStyles}>{JSON.stringify(json || {}, null, 2)}</pre>
+        </TabPanel>
+      );
+    });
   }
 
   render() {
     return (
       <div style={{ width: '50%', overflow: 'auto' }}>
         <span style={PropsEditor.labelStyles}>PROPS</span>
-        <table style={this.props.style}>
-          <tbody>
-            {this.renderPropInputs()}
-          </tbody>
-        </table>
-        <div style={PropsEditor.examplePropsLabelStyles}>EXAMPLE PROPS</div>
-        <pre>{JSON.stringify(this.props.component.exampleProps || {}, null, 2)}</pre>
+        <Tabs
+          onSelect={this.handleSelect}
+        >
+          <TabList>
+            {this.renderTabs()}
+          </TabList>
+          {this.renderTabPanels()}
+          <TabPanel>
+            <table style={this.props.style}>
+              <tbody>
+                {this.renderPropInputs()}
+              </tbody>
+            </table>
+          </TabPanel>
+        </Tabs>
       </div>
     );
   }

--- a/src/components/Sandbox.jsx
+++ b/src/components/Sandbox.jsx
@@ -43,10 +43,8 @@ export default class Sandbox extends React.Component {
     this.setState({ messages: [] });
   }
 
-  onUpdateProps = (event, propName, value) => {
-    const updatedProps = Object.assign({}, this.state.componentProps, { [propName]: value });
-
-    this.setState({ componentProps: updatedProps });
+  onUpdateProps = (componentProps) => {
+    this.setState({ componentProps });
   }
 
   render() {
@@ -88,11 +86,11 @@ export default class Sandbox extends React.Component {
       };
     });
 
-    const props = Object.assign(
-      currentComponent.props || {},
-      events,
-      currentComponent.component.exampleProps || {}
-    );
+    const props = {
+      ...(currentComponent.props || {}),
+      ...events,
+      ...this.state.componentProps,
+    };
 
     return (
       <div className="sandbox" style={Sandbox.rootStyles}>
@@ -103,7 +101,7 @@ export default class Sandbox extends React.Component {
             <div style={Sandbox.variantTitleStyles}>{currentComponent.variant || 'Default'}</div>
           </div>
         </div>
-        <currentComponent.component {...props} {...this.state.componentProps} />
+        <currentComponent.component {...props} />
 
         <div style={{ display: 'flex', flexFlow: 'row nowrap', paddingTop: Styles.padding.default }}>
           <Console style={{ paddingTop: Styles.padding.default }} messages={this.state.messages} />


### PR DESCRIPTION
<img src="https://www.dropbox.com/s/vpxbuh6atew2ft4/Feb-20-2017%2017-32-27.gif?dl=1" width="480">

This is backwards compatible with current `exampleProps`. You can now make `exampleProps` be an array like so:

```js
  static exampleProps = [
    {
      name: 'Normal',
      props: {
        showCancel: true,
        showDelete: true,
      },
    },
    {
      name: 'Deleting',
      props: {
        showCancel: true,
        showDelete: true,
        isDeleting: true,
      },
    },
    {
      name: 'Loading',
      props: {
        showCancel: true,
        showDelete: true,
        isLoading: true,
      },
    },
  ];
```

